### PR TITLE
Wrap the class in a proper module export

### DIFF
--- a/VRControls.js
+++ b/VRControls.js
@@ -2,124 +2,126 @@
  * @author dmarcos / https://github.com/dmarcos
  * @author mrdoob / http://mrdoob.com
  */
+module.exports = function(THREE) {
+	var VRControls = function ( object, onError ) {
 
-THREE.VRControls = function ( object, onError ) {
+		var scope = this;
 
-	var scope = this;
+		var vrInputs = [];
 
-	var vrInputs = [];
+		function filterInvalidDevices( devices ) {
 
-	function filterInvalidDevices( devices ) {
+			// Exclude Cardboard position sensor if Oculus exists.
 
-		// Exclude Cardboard position sensor if Oculus exists.
+			var oculusDevices = devices.filter( function ( device ) {
 
-		var oculusDevices = devices.filter( function ( device ) {
-
-			return device.deviceName.toLowerCase().indexOf( 'oculus' ) !== - 1;
-
-		} );
-
-		if ( oculusDevices.length >= 1 ) {
-
-			return devices.filter( function ( device ) {
-
-				return device.deviceName.toLowerCase().indexOf( 'cardboard' ) === - 1;
+				return device.deviceName.toLowerCase().indexOf( 'oculus' ) !== - 1;
 
 			} );
 
-		} else {
+			if ( oculusDevices.length >= 1 ) {
 
-			return devices;
+				return devices.filter( function ( device ) {
 
-		}
+					return device.deviceName.toLowerCase().indexOf( 'cardboard' ) === - 1;
 
-	}
+				} );
 
-	function gotVRDevices( devices ) {
+			} else {
 
-		devices = filterInvalidDevices( devices );
-
-		for ( var i = 0; i < devices.length; i ++ ) {
-
-			if ( devices[ i ] instanceof PositionSensorVRDevice ) {
-
-				vrInputs.push( devices[ i ] );
+				return devices;
 
 			}
 
 		}
 
-		if ( onError ) onError( 'HMD not available' );
+		function gotVRDevices( devices ) {
 
-	}
+			devices = filterInvalidDevices( devices );
 
-	if ( navigator.getVRDevices ) {
+			for ( var i = 0; i < devices.length; i ++ ) {
 
-		navigator.getVRDevices().then( gotVRDevices );
+				if ( devices[ i ] instanceof PositionSensorVRDevice ) {
 
-	}
+					vrInputs.push( devices[ i ] );
 
-	// the Rift SDK returns the position in meters
-	// this scale factor allows the user to define how meters
-	// are converted to scene units.
-
-	this.scale = 1;
-
-	this.update = function () {
-
-		for ( var i = 0; i < vrInputs.length; i ++ ) {
-
-			var vrInput = vrInputs[ i ];
-
-			var state = vrInput.getState();
-
-			if ( state.orientation !== null ) {
-
-				object.quaternion.copy( state.orientation );
+				}
 
 			}
 
-			if ( state.position !== null ) {
-
-				object.position.copy( state.position ).multiplyScalar( scope.scale );
-
-			}
+			if ( onError ) onError( 'HMD not available' );
 
 		}
 
-	};
+		if ( navigator.getVRDevices ) {
 
-	this.resetSensor = function () {
-
-		for ( var i = 0; i < vrInputs.length; i ++ ) {
-
-			var vrInput = vrInputs[ i ];
-
-			if ( vrInput.resetSensor !== undefined ) {
-
-				vrInput.resetSensor();
-
-			} else if ( vrInput.zeroSensor !== undefined ) {
-
-				vrInput.zeroSensor();
-
-			}
+			navigator.getVRDevices().then( gotVRDevices );
 
 		}
 
+		// the Rift SDK returns the position in meters
+		// this scale factor allows the user to define how meters
+		// are converted to scene units.
+
+		this.scale = 1;
+
+		this.update = function () {
+
+			for ( var i = 0; i < vrInputs.length; i ++ ) {
+
+				var vrInput = vrInputs[ i ];
+
+				var state = vrInput.getState();
+
+				if ( state.orientation !== null ) {
+
+					object.quaternion.copy( state.orientation );
+
+				}
+
+				if ( state.position !== null ) {
+
+					object.position.copy( state.position ).multiplyScalar( scope.scale );
+
+				}
+
+			}
+
+		};
+
+		this.resetSensor = function () {
+
+			for ( var i = 0; i < vrInputs.length; i ++ ) {
+
+				var vrInput = vrInputs[ i ];
+
+				if ( vrInput.resetSensor !== undefined ) {
+
+					vrInput.resetSensor();
+
+				} else if ( vrInput.zeroSensor !== undefined ) {
+
+					vrInput.zeroSensor();
+
+				}
+
+			}
+
+		};
+
+		this.zeroSensor = function () {
+
+			console.warn( 'THREE.VRControls: .zeroSensor() is now .resetSensor().' );
+			this.resetSensor();
+
+		};
+
+		this.dispose = function () {
+
+			vrInputs = [];
+
+		};
+
 	};
-
-	this.zeroSensor = function () {
-
-		console.warn( 'THREE.VRControls: .zeroSensor() is now .resetSensor().' );
-		this.resetSensor();
-
-	};
-
-	this.dispose = function () {
-
-		vrInputs = [];
-
-	};
-
-};
+	return VRControls
+}


### PR DESCRIPTION
When using this package in a browserify context, i think we should expect the THREE object to be passed in.  I'm not exactly sure how to use it currently without just copying/pasting, but if it lives in npm it should probably be requirable.  I used the pattern i found here: https://github.com/mattdesl/three-orbit-controls/blob/master/index.js

This lets you do

```
var THREE = require('three')
var VRControls = require('three-vrcontrols')(THREE)
```
